### PR TITLE
Added the ability to enable legacy swift mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ In a plugin's plugin.xml
     <dependency id="cordova-plugin-cocoapod-support"/>
 
     <platform name="ios">
-        <!-- optionally set minimum ios version and enable use_frameworks! -->
-        <pods-config ios-min-version="9.0" uses-frameworks="true"/>
+        <!-- optionally set minimum ios version, enable use_frameworks! and enable legacy swift (2.3)-->
+        <pods-config ios-min-version="9.0" use-frameworks="true" use-legacy="true"/>
         <pod id="LatestPod" />
         <pod id="VersionedPod" version="1.0.0" />
         <pod id="GitPod1" git="https://github.com/blakgeek/something" tag="v1.0.1" configuration="debug" />
@@ -93,6 +93,8 @@ or have a look at [the demo plugin](https://github.com/blakgeek/cordova-plugin-w
 ## Notes
 * Enabling the pods_use_frameworks preference disables the bridged headers property added by 
 [CB-10072](https://issues.apache.org/jira/browse/CB-10072).  This might cause odd behavior in some projects.  
+
+* If legacy is not used for swift the default version will be 3.0
 
 
 ##TODO:

--- a/scripts/podify.js
+++ b/scripts/podify.js
@@ -44,6 +44,7 @@ module.exports = function (context) {
         .then(createFiles)
         .then(installPods)
         .then(fixBundlePaths)
+        .then(fixSwiftLegacy)
         .then(updateBuild);
 
     function parseConfigXml() {
@@ -61,6 +62,12 @@ module.exports = function (context) {
                     }
                 });
             }
+        });
+    }
+
+    function getDirectories(srcpath) {
+        return fs.readdirSync(srcpath).filter(function(file) {
+            return fs.statSync(path.join(srcpath, file)).isDirectory();
         });
     }
 
@@ -86,7 +93,7 @@ module.exports = function (context) {
                                     if(podsConfig) {
                                         iosMinVersion = maxVer(iosMinVersion, podsConfig.$['ios-min-version']);
                                         useFrameworks = podsConfig.$['use-frameworks'] === 'true' ? 'true' : useFrameworks;
-                                        useLegacy = podsConfig.$['use-legacy'] === 'true' ? '2.3' : useLegacy;
+                                        useLegacy = podsConfig.$['use-legacy'] === 'true' ? '2.3' : '3.0';
                                     }
                                     (platform.pod || []).forEach(function (pod) {
                                         newPods.pods[pod.$.id] = pod.$;
@@ -178,14 +185,6 @@ module.exports = function (context) {
 
             }
 
-            if(useLegacy){
-                for(podId in newPods.pods){
-                    var podXcContents = fs.readFileSync('platforms/ios/Pods/Target Support Files/' + podId + '/' + podId + '.xcconfig', 'utf8');
-                    fs.writeFileSync('platforms/ios/Pods/Target Support Files/' + podId + '/' + podId + '.xconfig', podXcContents + '\n' + 'SWIFT_VERSION=2.3')
-                    console.log('Writing Legacy Swift Version 2.3');
-                }
-            }
-
             fs.writeFileSync(podConfigPath, JSON.stringify(newPods, null, '\t'));
         } else {
             console.log('No new pods detects');
@@ -244,6 +243,24 @@ module.exports = function (context) {
             fs.writeFileSync(podsResourcesSh, content);
         }
 
+
+        return shouldRun;
+    }
+
+
+    function fixSwiftLegacy(shouldRun){
+        var directories = getDirectories(path.join(__dirname + '/../../../platforms/ios/Pods/Target Support Files')),
+            podXcContents;
+        if(useLegacy){
+            for(var i = 0; i < directories.length; i++){
+                if(directories[i].indexOf(appName) === -1){
+                    podXcContents = fs.readFileSync('platforms/ios/Pods/Target Support Files/' + directories[i] + '/' + directories[i] + '.xcconfig', 'utf8');
+                    fs.writeFileSync('platforms/ios/Pods/Target Support Files/' + directories[i] + '/' + directories[i] + '.xcconfig', podXcContents + '\n' + 'SWIFT_VERSION=' + useLegacy)
+                }
+            }
+
+            console.log('Using Swift Version ' + useLegacy);
+        }
 
         return shouldRun;
     }


### PR DESCRIPTION
There was no option to determine the swift version for installed pods.  You can achieve this manually by changing the `Use Legacy Swift Language Version` flag in `Build Settings`. It would be better to do this automatically. Instructions on how to do this in the README.