### PR TITLE
added fix for finding destination (see issue #12)

### DIFF
--- a/scripts/podify.js
+++ b/scripts/podify.js
@@ -249,10 +249,13 @@ module.exports = function (context) {
             var projectFix = "'-workspace', projectName + '.xcworkspace',";
             var xcodeprojRegex = /\.xcodeproj/g;
             var xcodeprojFix = '.xcworkspace';
+            var destinationSimulatorOrg = "'-destination', 'platform=iOS Simulator'";
+            var destinationSimulatorNew = "'-destination generic/platform=iOS'";
             var fixedBuildContent = buildContent
                 .replace(targetRegex, targetFix)
                 .replace(projectRegex, projectFix)
-                .replace(xcodeprojRegex, xcodeprojFix);
+                .replace(xcodeprojRegex, xcodeprojFix)
+                .replace(destinationSimulatorOrg, destinationSimulatorNew);
 
             fs.writeFileSync('platforms/ios/cordova/lib/build.js', fixedBuildContent);
 


### PR DESCRIPTION
Fixed issue with build failing due to the inability to find the destination specifier 

```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
                { platform:iOS Simulator }

        Missing required device specifier option.
        The device type “iOS Simulator” requires that either “name” or “id” be specified.
        Please supply either “name” or “id”.
```

See [Issue 12](https://github.com/blakgeek/cordova-plugin-cocoapods-support/issues/12)

