### PR TITLE
Fix "use-frameworks" configuration in plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In a plugin's plugin.xml
 
     <platform name="ios">
         <!-- optionally set minimum ios version and enable use_frameworks! -->
-        <pods-config ios-min-version="9.0" uses-frameworks="true"/>
+        <pods-config ios-min-version="9.0" use-frameworks="true"/>
         <pod id="LatestPod" />
         <pod id="VersionedPod" version="1.0.0" />
         <pod id="GitPod1" git="https://github.com/blakgeek/something" tag="v1.0.1" configuration="debug" />


### PR DESCRIPTION
 "uses-framework" => "use-frameworks" in README plugin.xml example.
