### PR TITLE
fix: check directory presence when copying schemes

### DIFF
--- a/scripts/podify.js
+++ b/scripts/podify.js
@@ -238,6 +238,14 @@ module.exports = function (context) {
         return shouldRun;
     }
 
+    function createDirIfDoesNotExist(path) {
+        fs.statSync(path, function(stats) {
+            if (stats.isDirectory()) {
+                fs.mkdirSync(path);
+            }
+        });
+    }
+
     function updateBuild(shouldRun) {
 
         if(shouldRun) {
@@ -261,8 +269,8 @@ module.exports = function (context) {
 
             if (!podified) {
                 console.log('Adding schemes');
-                fs.mkdirSync(sharedDataDir);
-                fs.mkdirSync(schemesTargetDir);
+                createDirIfDoesNotExist(sharedDataDir);
+                createDirIfDoesNotExist(schemesTargetDir);
                 copyTpl(schemesSrcDir + '/CordovaLib.xcscheme', schemesTargetDir + '/CordovaLib.xcscheme', {
                     appName: appName
                 });


### PR DESCRIPTION
Hello

Worked on a simple fix for the error I described in [issue 19](https://github.com/blakgeek/cordova-plugin-cocoapods-support/issues/19).

As I understood the problem, an error is raised when adding schemes because a directory creation is demanded while the directory already exists.

The update I've made is a simple check for directory presence before trying to create it.

Wish it can help. From the tests I've done, there is no more error, everything seems to be fine.

Cheers