### PR TITLE
Add support for podspec configuration

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -11,5 +11,7 @@
         <engine name="cordova" version=">=3.0.0"/>
     </engines>
 
+    <hook type="before_plugin_install" src="scripts/beforePluginInstall.js" />
+
     <hook type="after_prepare" src="scripts/podify.js"/>
 </plugin>

--- a/scripts/beforePluginInstall.js
+++ b/scripts/beforePluginInstall.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+// Adapted from:
+// https://github.com/AllJoyn-Cordova/cordova-plugin-alljoyn/blob/master/scripts/beforePluginInstall.js
+
+var path = require('path');
+var exec = require('child_process').exec;
+
+// XXX FUTURE TBD auto-detect:
+var package_name = 'cordova-plugin-cocoapod-support';
+
+module.exports = function (context) {
+    var Q = context.requireCordovaModule('q');
+    var deferral = new Q.defer();
+
+    console.log('installing external dependencies via npm');
+
+    exec(   'npm install', {cwd: path.join('plugins', package_name)},
+            function (error, stdout, stderr) {
+                if (error !== null) {
+                    // XXX TODO SIGNAL FAILURE HERE.
+                    console.log('npm install of external dependencies failed: ' + error);
+                    deferral.resolve();
+                } else {
+                    console.log('npm install of external dependencies ok');
+                    deferral.resolve();
+                }
+            }
+    );
+
+    return deferral.promise;
+};

--- a/scripts/podify.js
+++ b/scripts/podify.js
@@ -157,7 +157,10 @@ module.exports = function (context) {
                         return "'" + config.trim() + "'";
                     });
                     entry += ", :subspecs => [" + configs.join() + "]";
+                } else if (pod.podspec) {
+                    entry += ", :podspec => '" + pod.podspec + "'";
                 }
+
                 podfileContents.push(entry);
             }
             podfileContents.push('end');


### PR DESCRIPTION
This will add missing podspec support.

Example:
`<pod id="MyPod" podspec="https://path.to.podspec">`
will add an entry to podfile:
`pod 'MyPod', :podspec => 'https://path.to.podspec'`