### PR TITLE
Add support for podspec configuration

### DIFF
--- a/scripts/podify.js
+++ b/scripts/podify.js
@@ -157,7 +157,10 @@ module.exports = function (context) {
                         return "'" + config.trim() + "'";
                     });
                     entry += ", :subspecs => [" + configs.join() + "]";
+                } else if (pod.podspec) {
+                    entry += ", :podspec => '" + pod.podspec + "'";
                 }
+
                 podfileContents.push(entry);
             }
             podfileContents.push('end');


### PR DESCRIPTION
This will add missing podspec support.

Example:
`<pod id="MyPod" podspec="https://path.to.podspec">`
will add an entry to podfile:
`pod 'MyPod', :podspec => 'https://path.to.podspec'`