### PR TITLE
Fix for cordova 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "^4.17.2",
+    "q": "^1.5.1",
     "semver": "^5.3.0",
     "shelljs": "^0.7.5",
     "xml2js": "^0.4.16"

--- a/scripts/podify.js
+++ b/scripts/podify.js
@@ -6,6 +6,8 @@ var path = require("path");
 var xml2js = require('xml2js');
 var spawn = require('child_process').spawn;
 var parser = new xml2js.Parser();
+var Q = require('q');
+var semver = require('semver');
 require('shelljs/global');
 
 module.exports = function (context) {
@@ -14,7 +16,6 @@ module.exports = function (context) {
         return;
     }
 
-    var Q = context.requireCordovaModule('q');
     var podfileContents = [];
     var rootPath = context.opts.projectRoot;
     var configXmlPath = path.join(rootPath, 'config.xml');
@@ -348,13 +349,13 @@ module.exports = function (context) {
     }
 
     function getConfigParser(context, config) {
-        var semver = context.requireCordovaModule('semver');
         var ConfigParser;
-
         if (semver.lt(context.opts.cordova.version, '5.4.0')) {
             ConfigParser = context.requireCordovaModule('cordova-lib/src/ConfigParser/ConfigParser');
-        } else {
+        } else if(semver.lt(context.opts.cordova.version, '9.0.0')){
             ConfigParser = context.requireCordovaModule('cordova-common/src/ConfigParser/ConfigParser');
+        } else {
+            ConfigParser = require('cordova-common/src/ConfigParser/ConfigParser');
         }
 
         return new ConfigParser(config);

--- a/scripts/podify.js
+++ b/scripts/podify.js
@@ -352,10 +352,8 @@ module.exports = function (context) {
         var ConfigParser;
         if (semver.lt(context.opts.cordova.version, '5.4.0')) {
             ConfigParser = context.requireCordovaModule('cordova-lib/src/ConfigParser/ConfigParser');
-        } else if(semver.lt(context.opts.cordova.version, '9.0.0')){
-            ConfigParser = context.requireCordovaModule('cordova-common/src/ConfigParser/ConfigParser');
         } else {
-            ConfigParser = require('cordova-common/src/ConfigParser/ConfigParser');
+            ConfigParser = context.requireCordovaModule('cordova-common/src/ConfigParser/ConfigParser');
         }
 
         return new ConfigParser(config);


### PR DESCRIPTION
I've made a small update in the podify.js file related to this issue: https://github.com/blakgeek/cordova-plugin-cocoapods-support/issues/47
With this update, Q and semver are required with a simple require, no matter which cordova version is used (I added q as plugin dependency)